### PR TITLE
Circular reference detection

### DIFF
--- a/ObjectFiller.Test/HashStackTests.cs
+++ b/ObjectFiller.Test/HashStackTests.cs
@@ -1,0 +1,36 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tynamix.ObjectFiller;
+
+namespace ObjectFiller.Test
+{
+    [TestClass]
+    public class HashStackTests
+    {
+        [TestMethod]
+        public void HashStack_PushSameItem_ReturnsFalse()
+        {
+            var s = new HashStack<int>();
+            s.Push(1);
+            var added = s.Push(1);
+
+            Assert.IsFalse(added);
+        }
+
+        [TestMethod]
+        public void HashStack_ContainsTest()
+        {
+            var s = new HashStack<int>();
+            s.Push(5);
+            Assert.AreEqual(true, s.Contains(5));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void HashStack_PopWithNoElements_Throws()
+        {
+            var s = new HashStack<int>();
+            s.Pop();
+        }
+    }
+}

--- a/ObjectFiller.Test/ObjectFiller.Test.csproj
+++ b/ObjectFiller.Test/ObjectFiller.Test.csproj
@@ -47,9 +47,11 @@
   <ItemGroup>
     <Compile Include="AddressFillingTest.cs" />
     <Compile Include="EnumTest.cs" />
+    <Compile Include="HashStackTests.cs" />
     <Compile Include="LibraryFillingTest.cs" />
     <Compile Include="ListFillingTest.cs" />
     <Compile Include="LoremIpsumPluginTest.cs" />
+    <Compile Include="ObjectFillerRecursiveTests.cs" />
     <Compile Include="PersonFillingTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ObjectFillerTest.cs" />

--- a/ObjectFiller.Test/ObjectFillerRecursiveTests.cs
+++ b/ObjectFiller.Test/ObjectFillerRecursiveTests.cs
@@ -1,0 +1,88 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Tynamix.ObjectFiller;
+
+namespace ObjectFiller.Test
+{
+    [TestClass]
+    public class ObjectFillerRecursiveTests
+    {
+
+        // ReSharper disable ClassNeverInstantiated.Local
+
+        private class TestParent
+        {
+            public TestChild Child { get; set; }
+        }
+
+        private class TestChild
+        {
+            public TestParent Parent { get; set; }
+        }
+
+        private class TestGrandParent
+        {
+            public TestParent SubObject { get; set; }
+        }
+
+        private class TestEmptyNode
+        {
+            public string Value { get; set; }
+        }
+
+        private class TestDuplicate
+        {
+            public TestEmptyNode Node1 { get; set; }
+            public TestEmptyNode Node2 { get; set; }
+        }
+
+        // ReSharper restore ClassNeverInstantiated.Local
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RecursiveFill_RecursiveType_ThrowsException()
+        {
+            var filler = new Filler<TestParent>();
+            filler.Create();
+        }
+
+        [TestMethod]
+        public void RecursiveFill_WithIgnoredProperties_Succeeds()
+        {
+            var filler = new Filler<TestParent>();
+            filler.Setup().OnProperty(p => p.Child).IgnoreIt();
+            var result = filler.Create();
+
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void RecursiveFill_WithFunc_Succeeds()
+        {
+            var filler = new Filler<TestParent>();
+            filler.Setup().OnProperty(p => p.Child).Use(() => new TestChild());
+            var result = filler.Create();
+
+            Assert.IsNotNull(result.Child);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void RecursiveFill_DeepRecursiveType_Succeeds()
+        {
+            var filler = new Filler<TestGrandParent>();
+            filler.Create();
+        }
+
+        [TestMethod]
+        public void RecursiveFill_DuplicateProperty_Succeeds()
+        {
+            // reason: a filler should not complain if it encounters the same type 
+            // in two separate branches of a type hierarchy
+            var filler = new Filler<TestDuplicate>();
+            var result = filler.Create();
+
+            Assert.IsNotNull(result);
+        }
+    }
+}

--- a/ObjectFiller/Filler.cs
+++ b/ObjectFiller/Filler.cs
@@ -134,17 +134,26 @@ namespace Tynamix.ObjectFiller
         }
 
 
-        private void FillInternal(object objectToFill)
+        private void FillInternal(object objectToFill, HashStack<Type> typeTracker = null)
         {
-            var currentSetup = SetupManager.GetFor(objectToFill.GetType());
+            var targetType = objectToFill.GetType();
 
-            if (currentSetup.TypeToRandomFunc.ContainsKey(objectToFill.GetType()))
+            if (typeTracker == null)
             {
-                objectToFill = currentSetup.TypeToRandomFunc[objectToFill.GetType()]();
+                // we only really use this in GetFilledPoco but we have to start somewhere...
+                typeTracker = new HashStack<Type>();
+                typeTracker.Push(targetType);
+            }
+
+            var currentSetup = SetupManager.GetFor(targetType);
+
+            if (currentSetup.TypeToRandomFunc.ContainsKey(targetType))
+            {
+                objectToFill = currentSetup.TypeToRandomFunc[targetType]();
                 return;
             }
 
-            var properties = objectToFill.GetType().GetProperties()
+            var properties = targetType.GetProperties()
                              .Where(x => GetSetMethodOnDeclaringType(x) != null).ToArray();
 
             if (properties.Length == 0) return;
@@ -170,7 +179,8 @@ namespace Tynamix.ObjectFiller
                     continue;
                 }
 
-                object filledObject = GetFilledObject(property.PropertyType, currentSetup);
+                object filledObject = GetFilledObject(property.PropertyType, currentSetup, typeTracker);
+
                 SetPropertyValue(property, objectToFill, filledObject);
             }
         }
@@ -238,7 +248,7 @@ namespace Tynamix.ObjectFiller
             return properties.Where(x => x.MetadataToken == property.MetadataToken && x.Module.Equals(property.Module));
         }
 
-        private object GetFilledObject(Type type, ObjectFillerSetup currentSetup)
+        private object GetFilledObject(Type type, ObjectFillerSetup currentSetup, HashStack<Type> typeTracker = null)
         {
             if (HasTypeARandomFunc(type, currentSetup))
             {
@@ -265,7 +275,7 @@ namespace Tynamix.ObjectFiller
 
             if (TypeIsPoco(type))
             {
-                return GetFilledPoco(type, currentSetup);
+                return GetFilledPoco(type, currentSetup, typeTracker);
             }
 
             if (TypeIsEnum(type))
@@ -276,8 +286,6 @@ namespace Tynamix.ObjectFiller
             object newValue = GetRandomValue(type, currentSetup);
             return newValue;
         }
-
-
 
         private object GetRandomEnumValue(Type type)
         {
@@ -291,11 +299,31 @@ namespace Tynamix.ObjectFiller
             return 0;
         }
 
-        private object GetFilledPoco(Type type, ObjectFillerSetup currentSetup)
+        private object GetFilledPoco(Type type, ObjectFillerSetup currentSetup, HashStack<Type> typeTracker)
         {
+            if (typeTracker != null)
+            {
+                if (typeTracker.Contains(type))
+                {
+                    throw new InvalidOperationException(
+                        string.Format(
+                            "The type {0} was already encountered before, which probably means you have a circular reference in your model. Either ignore the properties which cause this or specify explicit creation rules for them which do not rely on types.",
+                            type.Name));
+                }
+
+                typeTracker.Push(type);
+            }
+
             object result = CreateInstanceOfType(type, currentSetup);
 
-            FillInternal(result);
+            FillInternal(result, typeTracker);
+
+            if (typeTracker != null)
+            {
+                // once we fully filled the object, we can pop so other properties in the hierarchy can use the same types
+                typeTracker.Pop();
+            }
+
             return result;
         }
 

--- a/ObjectFiller/HashStack.cs
+++ b/ObjectFiller/HashStack.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tynamix.ObjectFiller
+{
+    /// <summary>
+    /// A stack-like collection that uses a HashSet under the covers, so elements also need to be unique.
+    /// </summary>
+    /// <remarks>
+    /// I decided to follow the HashSet more closely than the stack, 
+    /// which is why Push returns a boolean. I still think throwing an exception makes more
+    /// sense, but if HashSet does it people should be already familiar with the paradigm.
+    /// 
+    /// Pop however follows the standard stack implementation, of course.
+    /// </remarks>
+    public class HashStack<T> : IEnumerable<T>
+    {
+        private readonly HashSet<T> _set;
+        private readonly Stack<T> _stack;
+
+        public HashStack() : this(EqualityComparer<T>.Default)
+        {
+        }
+
+        public HashStack(IEqualityComparer<T> comparer)
+        {
+            _set = new HashSet<T>(comparer);
+            _stack = new Stack<T>();
+        }
+
+        /// <summary>
+        /// Adds the specified element to the HashStack.
+        /// </summary>
+        /// <returns>True if the element is added; false if the element is already present.</returns>
+        public bool Push(T item)
+        {
+            var added = _set.Add(item);
+            if (added) _stack.Push(item);
+            return added;
+        }
+
+        /// <summary>
+        /// Removes and returns the last added element.
+        /// </summary>
+        public T Pop()
+        {
+            var last = _stack.Pop();
+            _set.Remove(last);
+            return last;
+        }
+
+        public void Clear()
+        {
+            _set.Clear();
+            _stack.Clear();
+        }
+
+        public bool Contains(T item)
+        {
+            return _set.Contains(item);
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _stack.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/ObjectFiller/ObjectFiller.csproj
+++ b/ObjectFiller/ObjectFiller.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HashStack.cs" />
     <Compile Include="Setup\FluentFillerApi.cs" />
     <Compile Include="Setup\FluentPropertyApi.cs" />
     <Compile Include="Setup\FluentTypeApi.cs" />


### PR DESCRIPTION
A basic way of avoiding stack overflows with circular references in a
type hierarchy. Looks a bit messy but I have a feeling it can be
refactored into something nicer. Related to #20
