### PR TITLE
Non-static SetupManager

### DIFF
--- a/ObjectFiller/Filler.cs
+++ b/ObjectFiller/Filler.cs
@@ -14,11 +14,16 @@ namespace Tynamix.ObjectFiller
     /// <typeparam name="T">Targettype of the object to fill</typeparam>
     public class Filler<T> where T : class
     {
+
+        internal SetupManager SetupManager { get; private set; }
+
         /// <summary>
         /// Default constructor
         /// </summary>
         public Filler()
         {
+            SetupManager = new SetupManager();
+
             SetupManager.Clear();
         }
 
@@ -28,7 +33,7 @@ namespace Tynamix.ObjectFiller
         /// <returns>Fluent API setup</returns>
         public FluentFillerApi<T> Setup()
         {
-            return new FluentFillerApi<T>();
+            return new FluentFillerApi<T>(SetupManager);
         }
 
 

--- a/ObjectFiller/Setup/FluentFillerApi.cs
+++ b/ObjectFiller/Setup/FluentFillerApi.cs
@@ -13,13 +13,20 @@ namespace Tynamix.ObjectFiller
     public class FluentFillerApi<TTargetObject>
         where TTargetObject : class
     {
+        private SetupManager SetupManager { get; set; }
+
+        internal FluentFillerApi(SetupManager setupManager)
+        {
+            SetupManager = setupManager;
+        }
+
         /// <summary>
         /// Start to configure a type for objectfiller. The follow up methods will be found in the <see cref="FluentTypeApi{TTargetObject,TTargetType}"/>
         /// </summary>
         /// <typeparam name="TTargetType">Type which will be configured. For example string, int, etc...</typeparam>
         public FluentTypeApi<TTargetObject, TTargetType> OnType<TTargetType>()
         {
-            return new FluentTypeApi<TTargetObject, TTargetType>(this);
+            return new FluentTypeApi<TTargetObject, TTargetType>(this, SetupManager);
         }
 
         /// <summary>
@@ -54,7 +61,7 @@ namespace Tynamix.ObjectFiller
                 }
             }
 
-            return new FluentPropertyApi<TTargetObject, TTargetType>(propInfos, this);
+            return new FluentPropertyApi<TTargetObject, TTargetType>(propInfos, this, SetupManager);
         }
 
         /// <summary>
@@ -144,7 +151,7 @@ namespace Tynamix.ObjectFiller
         {
             SetupManager.SetNewFor<TNewType>(useDefaultSettings);
 
-            return new FluentFillerApi<TNewType>();
+            return new FluentFillerApi<TNewType>(SetupManager);
         }
 
     }

--- a/ObjectFiller/Setup/FluentPropertyApi.cs
+++ b/ObjectFiller/Setup/FluentPropertyApi.cs
@@ -14,11 +14,13 @@ namespace Tynamix.ObjectFiller
     {
         private readonly IEnumerable<PropertyInfo> _affectedProps;
         private readonly FluentFillerApi<TTargetObject> _callback;
+        private readonly SetupManager _setupManager;
 
-        internal FluentPropertyApi(IEnumerable<PropertyInfo> affectedProps, FluentFillerApi<TTargetObject> callback)
+        internal FluentPropertyApi(IEnumerable<PropertyInfo> affectedProps, FluentFillerApi<TTargetObject> callback, SetupManager setupManager)
         {
             _affectedProps = affectedProps;
             _callback = callback;
+            _setupManager = setupManager;
         }
 
         /// <summary>
@@ -31,7 +33,7 @@ namespace Tynamix.ObjectFiller
         {
             foreach (PropertyInfo propertyInfo in _affectedProps)
             {
-                SetupManager.GetFor<TTargetObject>().PropertyOrder[propertyInfo] = propertyOrder;
+                _setupManager.GetFor<TTargetObject>().PropertyOrder[propertyInfo] = propertyOrder;
             }
             return this;
         }
@@ -56,7 +58,7 @@ namespace Tynamix.ObjectFiller
         {
             foreach (PropertyInfo pInfo in _affectedProps)
             {
-                SetupManager.GetFor<TTargetObject>().PropertyToRandomFunc[pInfo] = () => randomizerFunc();
+                _setupManager.GetFor<TTargetObject>().PropertyToRandomFunc[pInfo] = () => randomizerFunc();
             }
             return _callback;
         }
@@ -91,7 +93,7 @@ namespace Tynamix.ObjectFiller
         {
             foreach (PropertyInfo pInfo in _affectedProps)
             {
-                SetupManager.GetFor<TTargetObject>().PropertiesToIgnore.Add(pInfo);
+                _setupManager.GetFor<TTargetObject>().PropertiesToIgnore.Add(pInfo);
             }
 
             return _callback;

--- a/ObjectFiller/Setup/FluentTypeApi.cs
+++ b/ObjectFiller/Setup/FluentTypeApi.cs
@@ -12,10 +12,12 @@ namespace Tynamix.ObjectFiller
         where TTargetObject : class
     {
         private readonly FluentFillerApi<TTargetObject> _callback;
+        private readonly SetupManager _setupManager;
 
-        internal FluentTypeApi(FluentFillerApi<TTargetObject> callback)
+        internal FluentTypeApi(FluentFillerApi<TTargetObject> callback, SetupManager setupManager)
         {
             _callback = callback;
+            _setupManager = setupManager;
         }
 
         /// <summary>
@@ -25,7 +27,7 @@ namespace Tynamix.ObjectFiller
         /// <returns>Main FluentFiller API</returns>
         public FluentFillerApi<TTargetObject> Use(Func<TTargetType> randomizerFunc)
         {
-            SetupManager.GetFor<TTargetObject>().TypeToRandomFunc[typeof(TTargetType)] = () => randomizerFunc();
+            _setupManager.GetFor<TTargetObject>().TypeToRandomFunc[typeof(TTargetType)] = () => randomizerFunc();
             return _callback;
         }
 
@@ -58,7 +60,7 @@ namespace Tynamix.ObjectFiller
         /// <returns>Main FluentFiller API</returns>
         public FluentFillerApi<TTargetObject> IgnoreIt()
         {
-            SetupManager.GetFor<TTargetObject>().TypesToIgnore.Add(typeof(TTargetType));
+            _setupManager.GetFor<TTargetObject>().TypesToIgnore.Add(typeof(TTargetType));
             return _callback;
         }
 
@@ -71,7 +73,7 @@ namespace Tynamix.ObjectFiller
         public FluentFillerApi<TTargetObject> CreateInstanceOf<TImplementation>()
             where TImplementation : class,TTargetType
         {
-            SetupManager.GetFor<TTargetObject>().InterfaceToImplementation.Add(typeof(TTargetType), typeof(TImplementation));
+            _setupManager.GetFor<TTargetObject>().InterfaceToImplementation.Add(typeof(TTargetType), typeof(TImplementation));
 
             return _callback;
         }

--- a/ObjectFiller/Setup/SetupManager.cs
+++ b/ObjectFiller/Setup/SetupManager.cs
@@ -6,15 +6,15 @@ namespace Tynamix.ObjectFiller
     /// <summary>
     /// Responsible to get the right <see cref="ObjectFillerSetup"/> for a given type.
     /// </summary>
-    internal static class SetupManager
+    internal class SetupManager
     {
-        private static ObjectFillerSetup _mainSetup;
-        private static Dictionary<Type, ObjectFillerSetup> _typeToSetup;
+        private ObjectFillerSetup _mainSetup;
+        private Dictionary<Type, ObjectFillerSetup> _typeToSetup;
 
         /// <summary>
         /// static ctor
         /// </summary>
-        static SetupManager()
+        internal SetupManager()
         {
             Clear();
         }
@@ -24,7 +24,7 @@ namespace Tynamix.ObjectFiller
         /// </summary>
         /// <typeparam name="TTargetObject">Type for which a <see cref="ObjectFillerSetup"/> will be get</typeparam>
         /// <returns><see cref="ObjectFillerSetup"/> for type <see cref="TTargetObject"/></returns>
-        internal static ObjectFillerSetup GetFor<TTargetObject>()
+        internal ObjectFillerSetup GetFor<TTargetObject>()
             where TTargetObject : class
         {
             return GetFor(typeof(TTargetObject));
@@ -35,7 +35,7 @@ namespace Tynamix.ObjectFiller
         /// </summary>
         /// <param name="targetType">Type for which a <see cref="ObjectFillerSetup"/> will be get</param>
         /// <returns><see cref="ObjectFillerSetup"/> for type <see cref="targetType"/></returns>
-        internal static ObjectFillerSetup GetFor(Type targetType)
+        internal ObjectFillerSetup GetFor(Type targetType)
         {
             if (_typeToSetup.ContainsKey(targetType))
             {
@@ -50,7 +50,7 @@ namespace Tynamix.ObjectFiller
         /// </summary>
         /// <typeparam name="TTargetObject">Type of target object for which a new <see cref="ObjectFillerSetup"/> will be set.</typeparam>
         /// <param name="useDefaultSettings">FALSE if the target object will take the settings of the parent object</param>
-        internal static void SetNewFor<TTargetObject>(bool useDefaultSettings)
+        internal void SetNewFor<TTargetObject>(bool useDefaultSettings)
             where TTargetObject : class
         {
             _typeToSetup[typeof(TTargetObject)] = useDefaultSettings ? new ObjectFillerSetup() : _mainSetup;
@@ -60,7 +60,7 @@ namespace Tynamix.ObjectFiller
         /// Set the main <see cref="ObjectFillerSetup"/>. This will be the root setup.
         /// </summary>
         /// <param name="setup">Main setup</param>
-        internal static void SetMain(ObjectFillerSetup setup)
+        internal void SetMain(ObjectFillerSetup setup)
         {
             _mainSetup = setup;
         }
@@ -68,7 +68,7 @@ namespace Tynamix.ObjectFiller
         /// <summary>
         /// Clears all the settings which was made.
         /// </summary>
-        internal static void Clear()
+        internal void Clear()
         {
             _mainSetup = new ObjectFillerSetup();
             _typeToSetup = new Dictionary<Type, ObjectFillerSetup>();


### PR DESCRIPTION
An obvious side effect is that we now need to pass the SetupManager down to all the classes that need it, but has the huge advantage of all fillers being isolated and free of side effects. Everything else should still work as before anyway, it's just a bit more isolated now.
