### PR TITLE
Fix: Dictionaries and SortedLists caused an exception

### DIFF
--- a/ObjectFiller.Test/ListFillingTest.cs
+++ b/ObjectFiller.Test/ListFillingTest.cs
@@ -7,6 +7,8 @@ using Tynamix.ObjectFiller;
 
 namespace ObjectFiller.Test
 {
+    using ObjectFiller.Test.TestPoco;
+
     [TestClass]
     public class ListFillingTest
     {
@@ -131,6 +133,16 @@ namespace ObjectFiller.Test
             }
         }
 
+        [TestMethod]
+        public void GenerateDictionaryWithEnumeration()
+        {
+            var amountOfEnumValues = Enum.GetValues(typeof(TestEnum)).Length;
+            var filler = new Filler<Dictionary<TestEnum, string>>();
+            var result = filler.Create();
+
+            Assert.AreEqual(amountOfEnumValues, result.Count);
+        }
+
         private Entity[] GetArray()
         {
             Filler<Entity> of = new Filler<Entity>();
@@ -146,9 +158,7 @@ namespace ObjectFiller.Test
             entities.Add(of.Create());
             entities.Add(of.Create());
 
-
             return entities.ToArray();
         }
-
     }
 }

--- a/ObjectFiller.Test/LoremIpsumPluginTest.cs
+++ b/ObjectFiller.Test/LoremIpsumPluginTest.cs
@@ -6,6 +6,8 @@ using Tynamix.ObjectFiller;
 
 namespace ObjectFiller.Test
 {
+    using System.Collections.Generic;
+
     [TestClass]
     public class LoremIpsumPluginTest
     {
@@ -73,6 +75,23 @@ namespace ObjectFiller.Test
             Assert.IsNotNull(b);
             Assert.IsNotNull(b1);
             Assert.AreEqual(b.ISBN, b1.ISBN);
+        }
+
+        [TestMethod]
+        public void LoremIpsum_should_provide_different_data()
+        {
+            var alowedDelta = 2;
+
+            var filler = new Filler<Book>();
+            filler.Setup()
+                .OnProperty(foo => foo.Description)
+                .Use(new Lipsum(LipsumFlavor.LoremIpsum));
+
+            var resultElements = filler.Create(100);
+
+            var groupedResult = resultElements.GroupBy(x => x.Description);
+
+            Assert.AreEqual(100, groupedResult.Count(), alowedDelta);
         }
     }
 }

--- a/ObjectFiller.Test/ObjectFiller.Test.csproj
+++ b/ObjectFiller.Test/ObjectFiller.Test.csproj
@@ -82,6 +82,7 @@
     <Compile Include="TestPoco\SimpleList.cs" />
     <Compile Include="SaveFillerSetupTest.cs" />
     <Compile Include="EmailAddressesPluginTest.cs" />
+    <Compile Include="TestPoco\TestEnum.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ObjectFiller\ObjectFiller.csproj">

--- a/ObjectFiller.Test/RandomizerTest.cs
+++ b/ObjectFiller.Test/RandomizerTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace ObjectFiller.Test
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -45,7 +46,16 @@
                 Assert.IsNotNull(ex.InnerException);
                 throw;
             }
-            
+        }
+
+        [TestMethod]
+        public void RandomizerCreatesAListOfRandomItemsIfNeeded()
+        {
+            int amount = 5;
+
+            IEnumerable<int> result = Randomizer<int>.Create(amount);
+
+            Assert.AreEqual(amount, result.Count());
         }
 
     }

--- a/ObjectFiller.Test/TestPoco/TestEnum.cs
+++ b/ObjectFiller.Test/TestPoco/TestEnum.cs
@@ -1,0 +1,13 @@
+namespace ObjectFiller.Test.TestPoco
+{
+    using System;
+
+    [Flags]
+    public enum TestEnum
+    {
+        ValueOne,
+        ValueTwo,
+        ValueThree,
+        ValueFour
+    }
+}

--- a/ObjectFiller/Filler.cs
+++ b/ObjectFiller/Filler.cs
@@ -86,22 +86,9 @@ namespace Tynamix.ObjectFiller
         public IEnumerable<T> Create(int count)
         {
             IList<T> items = new List<T>();
-            var typeStack = new HashStack<Type>();
-            Type targetType = typeof(T);
             for (int n = 0; n < count; n++)
             {
-                T objectToFill;
-                if (!TypeIsClrType(targetType))
-                {
-                    objectToFill = (T)this.CreateInstanceOfType(targetType, this.setupManager.GetFor<T>(), typeStack);
-                    this.Fill(objectToFill);
-                }
-                else
-                {
-                    objectToFill = (T)this.CreateAndFillObject(typeof(T), this.setupManager.GetFor<T>(), typeStack);
-                }
-
-                items.Add(objectToFill);
+                items.Add(this.Create());
             }
 
             return items;

--- a/ObjectFiller/Filler.cs
+++ b/ObjectFiller/Filler.cs
@@ -635,13 +635,30 @@ namespace Tynamix.ObjectFiller
             Type keyType = propertyType.GetGenericArguments()[0];
             Type valueType = propertyType.GetGenericArguments()[1];
 
-            int maxDictionaryItems = Random.Next(
+            int maxDictionaryItems = 0;
+
+            if (keyType.IsEnum)
+            {
+                maxDictionaryItems = Enum.GetValues(keyType).Length;
+            }
+            else
+            {
+                maxDictionaryItems = Random.Next(
                 currentSetupItem.DictionaryKeyMinCount,
                 currentSetupItem.DictionaryKeyMaxCount);
+            }
 
             for (int i = 0; i < maxDictionaryItems; i++)
             {
-                object keyObject = this.CreateAndFillObject(keyType, currentSetupItem, typeTracker);
+                object keyObject = null;
+                if (keyType.IsEnum)
+                {
+                    keyObject = Enum.GetValues(keyType).GetValue(i);
+                }
+                else
+                {
+                    keyObject = this.CreateAndFillObject(keyType, currentSetupItem, typeTracker);
+                }
 
                 if (dictionary.Contains(keyObject))
                 {

--- a/ObjectFiller/Plugins/String/Lipsum.cs
+++ b/ObjectFiller/Plugins/String/Lipsum.cs
@@ -39,7 +39,7 @@ namespace Tynamix.ObjectFiller
         private readonly int maxSentences;
         private readonly int minWords;
         private readonly int maxWords;
-        private readonly int seed;
+        private readonly int? seed;
 
         /// <summary>
         /// Words for the standard lorem ipsum text.
@@ -130,6 +130,8 @@ namespace Tynamix.ObjectFiller
         /// </summary>
         private readonly Dictionary<LipsumFlavor, string[]> map;
 
+        private System.Random random;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Lipsum"/> class.
         /// </summary>
@@ -152,7 +154,7 @@ namespace Tynamix.ObjectFiller
         /// The max words of the generated text.
         /// </param>
         /// <param name="seed">
-        /// The seed for the random to get the same result with the same seed.
+        /// The seed for randomizer to get the same result with the same seed.
         /// </param>
         public Lipsum(LipsumFlavor flavor, int paragraphs = 3, int minSentences = 3, int maxSentences = 8,
             int minWords = 10, int maxWords = 50, int? seed = null)
@@ -172,7 +174,8 @@ namespace Tynamix.ObjectFiller
                                { LipsumFlavor.LeMasque, LeMasque }
             };
 
-            this.seed = seed.HasValue ? seed.Value : Environment.TickCount;
+            this.seed = seed;
+            this.random = new System.Random();
         }
 
         /// <summary>
@@ -181,20 +184,23 @@ namespace Tynamix.ObjectFiller
         /// <returns>Random data for type <see cref="T"/></returns>
         public string GetValue()
         {
-            System.Random rnd = new System.Random(this.seed);
-            var array = this.map[this.flavor];
+            if (this.seed.HasValue)
+            {
+                this.random = new System.Random(this.seed.Value);
+            }
 
+            var array = this.map[this.flavor];
             var result = new StringBuilder();
 
             for (var i = 0; i < this.paragraphs; i++)
             {
-                var sentences = rnd.Next(this.minSentences, this.maxSentences + 1);
+                var sentences = this.random.Next(this.minSentences, this.maxSentences + 1);
                 for (var j = 0; j < sentences; j++)
                 {
-                    var words = rnd.Next(this.minWords, this.maxWords + 1);
+                    var words = this.random.Next(this.minWords, this.maxWords + 1);
                     for (var k = 0; k < words; k++)
                     {
-                        var word = array[rnd.Next(array.Length)];
+                        var word = array[this.random.Next(array.Length)];
                         if (k == 0)
                         {
                             word = System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(word);

--- a/ObjectFiller/Randomizer.cs
+++ b/ObjectFiller/Randomizer.cs
@@ -10,7 +10,9 @@
 namespace Tynamix.ObjectFiller
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.CompilerServices;
 
     /// <summary>
     /// This class is a easy way to get random values. 
@@ -63,6 +65,22 @@ namespace Tynamix.ObjectFiller
             }
 
             return (T)Setup.TypeToRandomFunc[typeof(T)]();
+        }
+
+        /// <summary>
+        /// Creates a set of random items of the given type. It will use a <see cref="IRandomizerPlugin{T}"/> for that.
+        /// </summary>
+        /// <param name="amount">Amount of items created.</param>
+        /// <returns>Set of random items of the given type.</returns>
+        public static IEnumerable<T> Create(int amount)
+        {
+            var resultSet = new List<T>();
+            for (int i = 0; i < amount; i++)
+            {
+                resultSet.Add(Create());
+            }
+
+            return resultSet;
         }
 
         /// <summary>


### PR DESCRIPTION
Dictionaries and SortedLists caused an exception when enumerations were used as keys. Now we create one entry for each value of the enumeration thus, none of the values is used more than once.