### PR TITLE
Setups can now be reused in other setups as well as the Randomizer class

### DIFF
--- a/ObjectFiller.Test/ObjectFiller.Test.csproj
+++ b/ObjectFiller.Test/ObjectFiller.Test.csproj
@@ -85,6 +85,7 @@
     <Compile Include="SaveFillerSetupTest.cs" />
     <Compile Include="EmailAddressesPluginTest.cs" />
     <Compile Include="TestPoco\TestEnum.cs" />
+    <Compile Include="SetupTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ObjectFiller\ObjectFiller.csproj">

--- a/ObjectFiller.Test/SetupTests.cs
+++ b/ObjectFiller.Test/SetupTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ObjectFiller.Test
+{
+    using Tynamix.ObjectFiller;
+
+    [TestClass]
+    public class SetupTests
+    {
+        public class Parent
+        {
+            public Child Child { get; set; }
+        }
+
+        public class Child
+        {
+            public int Value { get; set; }
+        }
+
+        [TestMethod]
+        public void RandomizerCreatesObjectsBasedOnPreviouseSetups()
+        {
+            int givenValue = Randomizer<int>.Create();
+
+            var childFiller = new Filler<Child>();
+            var childSetup = childFiller.Setup().OnProperty(x => x.Value).Use(givenValue).Result;
+            
+            var child = Randomizer<Child>.Create(childSetup);
+            Assert.AreEqual(givenValue, child.Value);
+        }
+
+        [TestMethod]
+        public void UseSetupsAgainForPropertyConfigurations()
+        {
+            int givenValue = Randomizer<int>.Create();
+
+            var childFiller = new Filler<Child>();
+            var childSetup = childFiller.Setup().OnProperty(x => x.Value).Use(givenValue).Result;
+
+            var parentFiller = new Filler<Parent>();
+            parentFiller.Setup().OnProperty(x => x.Child).Use(childSetup);
+
+            var parent = parentFiller.Create();
+            Assert.AreEqual(givenValue, parent.Child.Value);
+        }
+
+        [TestMethod]
+        public void UseSetupsAgainForTypeConfigurations()
+        {
+            int givenValue = Randomizer<int>.Create();
+
+            var childFiller = new Filler<Child>();
+            var childSetup = childFiller.Setup().OnProperty(x => x.Value).Use(givenValue).Result;
+
+            var parentFiller = new Filler<Parent>();
+            parentFiller.Setup().OnType<Child>().Use(childSetup);
+
+            var parent = parentFiller.Create();
+            Assert.AreEqual(givenValue, parent.Child.Value);
+        }
+
+        [TestMethod]
+        public void UseSetupsAgain()
+        {
+            int givenValue = Randomizer<int>.Create();
+
+            var firstChildFiller = new Filler<Child>();
+            var childSetup = firstChildFiller.Setup().OnProperty(x => x.Value).Use(givenValue).Result;
+
+            var secondChildFiller = new Filler<Child>();
+            secondChildFiller.Setup(childSetup);
+
+            var child = secondChildFiller.Create();
+
+            Assert.AreEqual(givenValue, child.Value);
+        }
+
+
+    }
+}

--- a/ObjectFiller/Setup/FluentPropertyApi.cs
+++ b/ObjectFiller/Setup/FluentPropertyApi.cs
@@ -108,6 +108,21 @@ namespace Tynamix.ObjectFiller
         }
 
         /// <summary>
+        /// Defines which <see cref="FillerSetup"/> is used to generate a value for the given <see cref="TTargetType"/>
+        /// </summary>
+        /// <param name="setup">The setup which is used for configuration.</param>
+        public FluentFillerApi<TTargetObject> Use(FillerSetup setup)
+        {
+            foreach (PropertyInfo propertyInfo in this.affectedProperties)
+            {
+                var factoryMethod = Randomizer<TTargetType>.CreateFactoryMethod(setup);
+                this.setupManager.GetFor<TTargetObject>().PropertyToRandomFunc[propertyInfo] = () => factoryMethod();
+            }
+
+            return this.callback;
+        }
+
+        /// <summary>
         /// Defines which implementation of the <see cref="IRandomizerPlugin{T}"/> interface will be used to generate a value for the given <see cref="TTargetType"/>
         /// </summary>
         /// <param name="randomizerPlugin">A <see cref="IRandomizerPlugin{TTargetType}"/> which will be used to generate a value of the <see cref="TTargetType"/></param>

--- a/ObjectFiller/Setup/FluentTypeApi.cs
+++ b/ObjectFiller/Setup/FluentTypeApi.cs
@@ -90,6 +90,19 @@ namespace Tynamix.ObjectFiller
         }
 
         /// <summary>
+        /// With this method you can use a previously defined setup for specific types.
+        /// </summary>
+        /// <param name="setup">The setup for the type.</param>
+        /// <returns>Main FluentFiller API</returns>
+        public FluentFillerApi<TTargetObject> Use(FillerSetup setup)
+        {
+            var factoryMethod = Randomizer<TTargetType>.CreateFactoryMethod(setup);
+            this.setupManager.GetFor<TTargetObject>().TypeToRandomFunc[typeof(TTargetType)] = () => factoryMethod();
+
+            return this.callback;
+        }
+
+        /// <summary>
         /// Ignores the entity for which the fluent setup is made (Type, Property)
         /// </summary>
         /// <returns>Main FluentFiller API</returns>
@@ -108,7 +121,8 @@ namespace Tynamix.ObjectFiller
         public FluentFillerApi<TTargetObject> CreateInstanceOf<TImplementation>()
             where TImplementation : class, TTargetType
         {
-            this.setupManager.GetFor<TTargetObject>().InterfaceToImplementation.Add(typeof(TTargetType), typeof(TImplementation));
+            this.setupManager.GetFor<TTargetObject>()
+                .InterfaceToImplementation.Add(typeof(TTargetType), typeof(TImplementation));
 
             return this.callback;
         }


### PR DESCRIPTION
Added overloads of Use so you can now use previously defined Setups in
other setups. I also extended the Randomizer Create method with a
parameter to use setups also with the Randomizer.