### PR TITLE
Fixing Bug with Multi Threaded Random Access

### DIFF
--- a/ObjectFiller.Test/RandomAccessTest.cs
+++ b/ObjectFiller.Test/RandomAccessTest.cs
@@ -1,0 +1,51 @@
+﻿namespace ObjectFiller.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+        using Xunit;
+
+    using ObjectFiller.Test.TestPoco.Library;
+    using ObjectFiller.Test.TestPoco.Person;
+
+    using Tynamix.ObjectFiller;
+
+
+    public class RandomAccessTest
+    {
+        [Fact]
+        public void GetRandomIntOnDifferentThreadsGetsDifferentResults()
+        {
+            var numberToGenerate = 1000;
+            var intRange = new IntRange(1, 10);
+            var task1 = Task.Factory.StartNew(() =>
+                {
+                    var taskResults = new List<int>();
+                    for (int i = 0; i < numberToGenerate; ++i)
+                    {
+                        taskResults.Add(Randomizer<int>.Create(intRange));
+                    }
+                    return taskResults;
+                },
+                TaskCreationOptions.LongRunning
+            );
+            var task2 = Task.Factory.StartNew(() =>
+                {
+                    var taskResults = new List<int>();
+                    for (int i = 0; i < numberToGenerate; ++i)
+                    {
+                        taskResults.Add(Randomizer<int>.Create(intRange));
+                    }
+                    return taskResults;
+                },
+                TaskCreationOptions.LongRunning
+            );
+            var results = Task.WhenAll(task1, task2).Result;
+            List<int> firstResults = results[0];
+            List<int> secondResults = results[1];
+            Assert.NotEqual(firstResults, secondResults);
+        }
+    }
+}

--- a/ObjectFiller/Random.cs
+++ b/ObjectFiller/Random.cs
@@ -19,24 +19,47 @@ namespace Tynamix.ObjectFiller
     /// </summary>
     internal static class Random
     {
+
+        private static int RandomSeed;
+        /// <summary>
+        /// Initializes static members of the <see cref="Random"/> class.
+        /// A instance of <see cref="Random"/>
+        /// </summary>
+        static Random()
+        {
+            RandomSeed = Environment.TickCount;
+        }
+
+#if NET3X
         /// <summary>
         /// A instance of <see cref="Random"/>
         /// </summary>
         [ThreadStatic]
-        private static readonly System.Random Rnd;
+        private static System.Random RndStorage;
+
+        private static System.Random Rnd
+        {
+            get
+            {
+                if (RndStorage == null)
+                {
+                    RndStorage = new System.Random(Interlocked.Increment(ref RandomSeed));
+                }
+                return RndStorage;
+            }
+        }
+#else
+        private static readonly ThreadLocal<System.Random> RndStorage = new ThreadLocal<System.Random>(() =>
+            new System.Random(Interlocked.Increment(ref RandomSeed)));
 
         /// <summary>
-        /// Initializes static members of the <see cref="Random"/> class.
+        /// A instance of <see cref="Random"/>
         /// </summary>
-        static Random()
+        private static System.Random Rnd
         {
-#if NETSTD
-            Rnd = new System.Random();
-#else
-            int seed = Environment.TickCount;
-            Rnd = new System.Random(Interlocked.Increment(ref seed));
-#endif
+            get { return RndStorage.Value; }
         }
+#endif
 
         /// <summary>
         /// Returns a nonnegative number


### PR DESCRIPTION
Adding test to verify multi threaded random support, and adjusting implementation to use ThreadStatic for NET3X, ThreadLocal for anything else.  Fixes bug with getting null Random instance when accessing on the second created thread, due to ThreadLocal variable only being instantiated once in the static constructor instead of once per thread.

If support for NET3X is ever deprecated the ThreadStatic implementation can be completely removed in favor of the ThreadLocal implementation.

#60 