### PR TITLE
Fix property detection in multi-level hierarchies

### DIFF
--- a/Tynamix.ObjectFiller/Filler.cs
+++ b/Tynamix.ObjectFiller/Filler.cs
@@ -657,7 +657,10 @@ namespace Tynamix.ObjectFiller
                 return;
             }
 
-            var properties = targetType.GetProperties(currentSetup.IgnoreInheritance)
+            var flags = BindingFlags.Public | BindingFlags.Instance;
+            if (currentSetup.IgnoreInheritance)
+                flags = flags | BindingFlags.DeclaredOnly;
+            var properties = targetType.GetProperties(flags)
                                        .Where(prop => this.GetSetMethodOnDeclaringType(prop) != null)
                                        .ToArray();
 


### PR DESCRIPTION
When a hierarchy has multiple levels, FillInternal() does not find public properties from higher up the hierarchy. Fixed the way that GetProperties() is called to ensure these properties are found.