### PR TITLE
Fixed typos in PatternGenerator doc

### DIFF
--- a/Tynamix.ObjectFiller/Plugins/String/PatternGenerator.cs
+++ b/Tynamix.ObjectFiller/Plugins/String/PatternGenerator.cs
@@ -13,8 +13,8 @@
 //   </list>
 //   The character patterns can refer to these character classes: <para />
 //   <list type="bullet">
-//   <item><description>a: lower-case ascii character, range is 'a' to 'a'</description></item>
-//   <item><description>A: upper-case ascii character, range is 'a' to 'a'</description></item>
+//   <item><description>a: lower-case ASCII character, range is 'a' to 'z'</description></item>
+//   <item><description>A: upper-case ASCII character, range is 'A' to 'Z'</description></item>
 //   <item><description>N: numbers from '0' to '9'</description></item>
 //   <item><description>X: hexadecimal digit from '0' to 'F'</description></item>
 //   </list>
@@ -47,8 +47,8 @@ namespace Tynamix.ObjectFiller
     /// </list>
     /// The character patterns can refer to these character classes: <para/>
     /// <list type="bullet">
-    /// <item><description>a: lower-case ascii character, range is 'a' to 'a'</description></item>
-    /// <item><description>A: upper-case ascii character, range is 'a' to 'a'</description></item>
+    /// <item><description>a: lower-case ASCII character, range is 'a' to 'z'</description></item>
+    /// <item><description>A: upper-case ASCII character, range is 'A' to 'Z'</description></item>
     /// <item><description>N: numbers from '0' to '9'</description></item>
     /// <item><description>X: hexadecimal digit from '0' to 'F'</description></item>
     /// </list>


### PR DESCRIPTION
Fix for some tiny typos in PatternGenerator documentation