### PR TITLE
Added test and implementation for LongRange

### DIFF
--- a/Tynamix.ObjectFiller.Test/RangePluginTest.cs
+++ b/Tynamix.ObjectFiller.Test/RangePluginTest.cs
@@ -51,5 +51,69 @@ namespace Tynamix.ObjectFiller.Test
             Assert.IsNotNull(sl.ChildList);
             Assert.IsTrue(sl.ChildList.All(x => x >= min && x <= max));
         }
+
+        [TestMethod]
+        public void TestLongRangeWithMaxValue()
+        {
+            long max = int.MaxValue * 10L;
+            Filler<SimpleList<long>> filler = new Filler<SimpleList<long>>();
+
+            filler.Setup().OnType<long>().Use(new LongRange(max));
+            var sl = filler.Create();
+
+            Assert.IsNotNull(sl);
+            Assert.IsNotNull(sl.ChildList);
+            Assert.IsTrue(sl.ChildList.All(x => x < max));
+            Assert.IsFalse(sl.ChildList.All(x => x == sl.ChildList[0]));
+        }
+
+        [TestMethod]
+        public void TestLongRangeWithMinMaxValue()
+        {
+            long min = int.MinValue * 10L;
+            long max = int.MaxValue * 10L;
+            Filler<SimpleList<long>> filler = new Filler<SimpleList<long>>();
+
+            filler.Setup().OnType<long>().Use(new LongRange(min, max));
+            var sl = filler.Create();
+
+            Assert.IsNotNull(sl);
+            Assert.IsNotNull(sl.ChildList);
+            Assert.IsTrue(sl.ChildList.All(x => x >= min && x <= max));
+            Assert.IsFalse(sl.ChildList.All(x => x == sl.ChildList[0]));
+        }
+
+        [TestMethod]
+        public void TestLongRangeWithMinMaxValueLowSmallRange()
+        {
+            long min = long.MinValue;
+            long max = long.MinValue + 10;
+            Filler<SimpleList<long>> filler = new Filler<SimpleList<long>>();
+
+            filler.Setup().OnType<long>().Use(new LongRange(min, max));
+            var sl = filler.Create();
+
+            Assert.IsNotNull(sl);
+            Assert.IsNotNull(sl.ChildList);
+            Assert.IsTrue(sl.ChildList.All(x => x >= min && x <= max));
+            Assert.IsFalse(sl.ChildList.All(x => x == sl.ChildList[0]));
+        }
+
+        [TestMethod]
+        public void TestLongRangeWithMinMaxValueHighSmallRange()
+        {
+            long min = long.MaxValue - 10;
+            long max = long.MaxValue;
+            Filler<SimpleList<long>> filler = new Filler<SimpleList<long>>();
+
+            filler.Setup().OnType<long>().Use(new LongRange(min, max));
+            var sl = filler.Create();
+
+            Assert.IsNotNull(sl);
+            Assert.IsNotNull(sl.ChildList);
+            Assert.IsTrue(sl.ChildList.All(x => x >= min && x <= max));
+            Assert.IsFalse(sl.ChildList.All(x => x == sl.ChildList[0]));
+        }
+
     }
 }

--- a/Tynamix.ObjectFiller/Plugins/Long/LongRange.cs
+++ b/Tynamix.ObjectFiller/Plugins/Long/LongRange.cs
@@ -1,0 +1,73 @@
+﻿namespace Tynamix.ObjectFiller
+{
+	using System;
+
+	/// <summary>
+	/// The 64-integer range plugin
+	/// </summary>
+	public class LongRange : IRandomizerPlugin<long>, IRandomizerPlugin<long?>
+	{
+		/// <summary>
+		/// The min value
+		/// </summary>
+		private readonly long min;
+
+		/// <summary>
+		/// The max value
+		/// </summary>
+		private readonly long max;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LongRange"/> class.
+		/// </summary>
+		/// <param name="min">
+		/// The min value
+		/// </param>
+		/// <param name="max">
+		/// The max value
+		/// </param>
+		public LongRange(long min, long max)
+		{
+			this.min = min;
+			this.max = max;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LongRange"/> class.
+		/// </summary>
+		/// <param name="max">
+		/// The max.
+		/// </param>
+		public LongRange(long max)
+			: this(long.MinValue, max)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LongRange"/> class.
+		/// </summary>
+		public LongRange()
+			: this(long.MinValue, long.MaxValue)
+		{
+		}
+
+		/// <summary>
+		/// Gets random data for type <see cref="long"/>
+		/// </summary>
+		/// <returns>Random data for type <see cref="long"/></returns>
+		public long GetValue()
+		{
+			return Random.NextLong(this.min, this.max);
+		}
+
+
+		/// <summary>
+		/// Gets random data for type <see cref="Nullable{Int64}"/>
+		/// </summary>
+		/// <returns>Random data for type <see cref="Nullable{Int64}"/></returns>
+		long? IRandomizerPlugin<long?>.GetValue()
+		{
+			return this.GetValue();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #122 

If this PR gets merged, will add ULong etc.
Maybe even a static method `Range.Get<T>(T? min, T? max)` where `T` is any numeric value int/uint/byte/double etc.